### PR TITLE
Rename 'owner' to 'uploader'.

### DIFF
--- a/handlers/packages.py
+++ b/handlers/packages.py
@@ -94,6 +94,6 @@ class Packages(object):
                 versions=package.version_set.order('-sort_order').fetch(10),
                 version_count=version_count,
                 show_versions_link=version_count > 10,
-                is_owner=package.owner == users.get_current_user())
+                is_uploader=package.owner == users.get_current_user())
         else:
             raise handlers.http_error(404)

--- a/models/package.py
+++ b/models/package.py
@@ -13,12 +13,14 @@ class Package(db.Model):
     """The model for a package.
 
     A package contains only metadata that applies to every version of the
-    package, such as its name and owner. Each individual version of the package
-    is represented by a PackageVersion model.
+    package, such as its name and uploader. Each individual version of the
+    package is represented by a PackageVersion model.
     """
 
+    # TODO(nweiz): This should more properly be called "uploader". Change the
+    # name once we support multiple uploaders for each package.
     owner = db.UserProperty(required=True, auto_current_user_add=True)
-    """The user who owns the package."""
+    """The user who is allowed to upload new versions of the package."""
 
     name = db.StringProperty(required=True)
     """The name of the package."""

--- a/test/test_handlers/test_package_versions.py
+++ b/test/test_handlers/test_package_versions.py
@@ -19,7 +19,7 @@ class PackageVersionsTest(TestCase):
         response = self.testapp.get('/packages/test-package/versions/new')
         self.assert_requires_login(response)
 
-    def test_new_requires_ownership(self):
+    def test_new_requires_uploadership(self):
         self.be_normal_user()
 
         response = self.testapp.get('/packages/test-package/versions/new')
@@ -28,7 +28,7 @@ class PackageVersionsTest(TestCase):
                          'http://localhost:80/packages/test-package')
         self.assertTrue(response.cookies_set.has_key('flash'))
 
-    def test_owner_creates_package_version(self):
+    def test_uploader_creates_package_version(self):
         self.be_admin_user()
         self.post_package_version('1.2.3')
 
@@ -38,7 +38,7 @@ class PackageVersionsTest(TestCase):
         self.assertEqual(version.package.name, 'test-package')
         self.assertEqual(self.latest_version(), SemanticVersion('1.2.3'))
 
-    def test_create_requires_owner(self):
+    def test_create_requires_uploader(self):
         self.be_normal_user()
         upload = self.upload_archive('test-package', '1.2.3')
         response = self.testapp.post(

--- a/views/packages/show.mustache
+++ b/views/packages/show.mustache
@@ -12,7 +12,7 @@
 {{#package.authors_html}}
   <h3>Authors: {{& package.authors_html}}</h3>
 {{/package.authors_html}}
-<h4>Owner: {{package.owner.nickname}}</h2>
+<h4>Uploader: {{package.owner.nickname}}</h2>
 <ul>
   {{#versions}}
     <li>
@@ -28,6 +28,6 @@
     </a>
   </p>
 {{/show_versions_link}}
-{{#is_owner}}
+{{#is_uploader}}
   <p><a href="/packages/{{package.name}}/versions/new">Add Version</a></p>
-{{/is_owner}}
+{{/is_uploader}}


### PR DESCRIPTION
This change leaves the database field as "owner" for now, since we're planning on pluralizing it eventually anyway.
