### PR TITLE
Show a real error page.

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -104,6 +104,14 @@ def is_production():
     """Return whether we're running in production mode."""
     return bool(os.environ.get('DATACENTER'))
 
+def is_dev_server():
+    """Return whether we're running on locally or on AppEngine.
+
+    Note that this returns True in tests so that the test appear to run in a
+    non-dev-server-like environment.
+    """
+    return os.environ['SERVER_SOFTWARE'].startswith('Development')
+
 def request():
     """Return the current Request instance."""
     if not hasattr(cherrypy.request, 'pub_data'):

--- a/pub_dartlang.py
+++ b/pub_dartlang.py
@@ -84,7 +84,8 @@ class Application(cherrypy.Application):
         self.dispatcher.mapper.resource(member_name, collection_name, **kwargs)
 
 def _error_page(status, message, traceback, version):
-    if not users.is_current_user_admin():
+    # Don't show tracebacks to end users.
+    if not handlers.is_dev_server() and not users.is_current_user_admin():
         traceback = None
 
     return str(handlers.render('error',

--- a/test/test_handlers/test_error.py
+++ b/test/test_handlers/test_error.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+# for details. All rights reserved. Use of this source code is governed by a
+# BSD-style license that can be found in the LICENSE file.
+
+from testcase import TestCase
+
+from models.package import Package
+
+class ErrorTest(TestCase):
+    def test_error_traceback_requires_admin(self):
+        self.be_normal_user()
+        response = self.testapp.get('/not/real/here/comes/a/404', status=404)
+        self.assert_error_page(response)
+        self.assertIsNone(self.html(response).find('pre', 'traceback'))
+
+        self.be_admin_user()
+        response = self.testapp.get('/not/real/here/comes/a/404', status=404)
+        self.assert_error_page(response)
+        self.assertIsNotNone(self.html(response).find('pre', 'traceback'))

--- a/test/testcase.py
+++ b/test/testcase.py
@@ -3,6 +3,7 @@
 # BSD-style license that can be found in the LICENSE file.
 
 import base64
+import os
 import unittest
 from cStringIO import StringIO
 
@@ -57,6 +58,11 @@ class TestCase(unittest.TestCase):
         self.testbed.init_user_stub()
 
         self.testapp = webtest.TestApp(Application())
+
+        # Pretend we are running on AppEngine so that things like the error
+        # page that behave differently when run locally act like they do in
+        # production.
+        os.environ['SERVER_SOFTWARE'] = 'Google App Engine/TESTING'
 
         # This private key is not actually used for anything other than testing.
         PrivateKey.set('''-----BEGIN RSA PRIVATE KEY-----

--- a/test/testcase.py
+++ b/test/testcase.py
@@ -214,9 +214,8 @@ cMJfCVm8pqhXwCVx3uYnhUzvth7mcEseXh5Dcg1RHka5rCXUz4eVxTkj1u3FOy9o
         Arguments:
           response: The webtest response object to check.
         """
-        # TODO(nweiz): Make a better error page that's easier to detect
-        error_pre = self.html(response).find('pre', id='traceback')
-        self.assertTrue(error_pre is not None, "expected error page")
+        error = self.html(response).find("p", "error-message")
+        self.assertTrue(error is not None, "expected error page")
 
     def html(self, response):
         """Parse a webtest response with BeautifulSoup.

--- a/views/error.mustache
+++ b/views/error.mustache
@@ -5,6 +5,5 @@
 <h1>Error {{status}}</h1>
 <p class="error-message">{{message}}</p>
 {{#traceback}}
-<pre class="traceback">
-{{traceback}}</pre>
+<pre class="traceback">{{traceback}}</pre>
 {{/traceback}}

--- a/views/error.mustache
+++ b/views/error.mustache
@@ -1,0 +1,10 @@
+{{! Copyright (c) 2012, the Dart project authors.  Please see the AUTHORS file
+    for details. All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE file. }}
+
+<h1>Error {{status}}</h1>
+<p class="error-message">{{message}}</p>
+{{#traceback}}
+<pre class="traceback">
+{{traceback}}</pre>
+{{/traceback}}


### PR DESCRIPTION
Critically, do not show the stack trace if the user isn't an admin.
