### PR TITLE
Redirect /doc to /doc/ so relative URLs work.

### DIFF
--- a/handlers/doc.py
+++ b/handlers/doc.py
@@ -7,12 +7,16 @@ import itertools
 import os
 import re
 
+import cherrypy
 import yaml
 
 import handlers
 
 class Doc(object):
     """The handler for /doc/*."""
+
+    def index(self):
+        raise cherrypy.HTTPRedirect('/doc/')
 
     def show(self, filename):
         """Display a documentation page.

--- a/pub_dartlang.py
+++ b/pub_dartlang.py
@@ -41,10 +41,10 @@ class Application(cherrypy.Application):
         self.dispatcher.mapper.connect(
             '/gs_/{filename:.*?}', controller='root', action='serve')
 
+        self.dispatcher.connect('doc', '/doc', Doc(), action='index')
         self.dispatcher.connect(
             'doc', '/doc/{filename:.*?}', Doc(), action='show')
-        self.dispatcher.connect(
-            'doc', '/doc', Doc(), action='show', filename='index.html')
+
         self._resource('package', 'packages', Packages())
         self._resource('private-key', 'private-keys', PrivateKeys())
 


### PR DESCRIPTION
Fixes: http://code.google.com/p/dart/issues/detail?id=5421.
