### PR TITLE
Don't wrap unknown exceptions in JSON in json_or_html_action.

### DIFF
--- a/handlers/__init__.py
+++ b/handlers/__init__.py
@@ -159,8 +159,6 @@ def json_or_html_action(fn, *args, **kwargs):
         raise JsonError(400, err.message)
     except oauth.OAuthRequestError as err:
         raise JsonError(403, "OAuth2 authentication failed.")
-    except Exception as err:
-        raise JsonError(500, err.message)
 
 @decorator
 @json_or_html_action


### PR DESCRIPTION
The errors are already wrapped in _error_page in pub_dartlang.py, and
re-wrapping them just serves to hide the stack traces which would otherwise be
printed to stderr.
