### PR TITLE
Fix detection of development/production mode.

### DIFF
--- a/app/handlers/__init__.py
+++ b/app/handlers/__init__.py
@@ -274,12 +274,12 @@ def is_current_user_dogfooder():
 
 def is_production():
     """Return whether we're running in production mode."""
-    return bool(os.environ.get('DATACENTER'))
+    return not is_dev_server()
 
 def is_dev_server():
     """Return whether we're running on locally or on AppEngine.
 
-    Note that this returns True in tests so that the test appear to run in a
+    Note that this returns False in tests so that the test appear to run in a
     non-dev-server-like environment.
     """
     return os.environ['SERVER_SOFTWARE'].startswith('Development')


### PR DESCRIPTION
As of the 1.7.6 SDK, the DATACENTER environment variable was set in development.
