### PR TITLE
Update docs to match the latest pub behavior:

### DIFF
--- a/app/doc/package-layout.markdown
+++ b/app/doc/package-layout.markdown
@@ -5,6 +5,7 @@ title: "Package layout conventions"
 1. [The basics](#the-basics)
 1. [README](#readme)
 1. [Public libraries](#public-libraries)
+1. [Public assets](#public-assets)
 1. [Implementation files](#implementation-files)
 1. [Web files](#web-files)
 1. [Command-line apps](#command-line-apps)
@@ -35,6 +36,8 @@ would look like:
       pubspec.lock *
       README.md
       LICENSE
+      asset/
+        guacamole.css
       benchmark/
         make_lunch.dart
         packages/ **
@@ -130,7 +133,7 @@ Many packages are [*library packages*](glossary.html#library-package): they
 define Dart libraries that other packages can import and use. These public Dart
 library files go inside a directory called `lib`.
 
-Most packages will define a single library that users can import. In that case,
+Most packages define a single library that users can import. In that case,
 its name should usually be the same as the name of the package, like
 `enchilada.dart` in the example here. But you can also define other libraries
 with whatever names make sense for your package.
@@ -164,6 +167,41 @@ with a `main()` function&mdash;cannot go in `lib`. If you place a Dart script
 inside `lib`, you will discover that any `package:` imports it contains don't
 resolve. Instead, your entrypoints should go in the appropriate
 [entrypoint directory](glossary.html#entrypoint-directory).
+
+## Public assets
+
+    enchilada/
+      asset/
+        guacamole.css
+
+While most library packages exist to let you reuse Dart code, you can also
+reuse other kinds of content. For example, a package for something like
+[Bootstrap](http://getbootstrap.com/) might include a number of CSS files for
+consumers of the package to use.
+
+These go in a top-level directory named `asset`. You can put any kind of file
+in there and organize it with subdirectories however you like. It's effectively
+a `lib` directory for stuff that isn't Dart code.
+
+Users can reference another package's assets using URLs that contain
+`assets/<package>/<path>` where `<package>` is the name of the package
+containing the asset and `<path>` is the relative path to the asset within that
+package's `asset` directory.
+
+Note that `assets` is plural in the URL. This is a bit like the split between
+`lib` and `packages`. The former is the name of the *directory in the package*,
+the latter is the *name you use to reference it*.
+
+For example, let's say your package wanted to use enchilada's `guacamole.css`
+styles. In an HTML file in your package, you can add:
+
+{% highlight html %}
+<link href="assets/enchilada/guacamole.css" rel="stylesheet">
+{% endhighlight %}
+
+When you run your application using [`pub serve`](pub-serve.html), or build it
+to something deployable using [`pub build`](pub-build.html), Pub will copy over
+any referenced assets that your package depends on.
 
 ## Implementation files
 

--- a/app/doc/pub-build.markdown
+++ b/app/doc/pub-build.markdown
@@ -2,7 +2,7 @@
 title: "Command: Build"
 ---
 
-    $ pub build [--no-minify]
+    $ pub build [--mode=<mode>]
 
 Use `pub build` when you're ready to deploy your web app. When you run
 `pub build`, it generates the [assets](glossary.html#asset) for the current
@@ -37,7 +37,15 @@ development server that continuously generates and serves assets.
 
 ## Options
 
-### `--no-minify`
+### `--mode=<mode>`
 
-By default, pub generates minified JavaScript ready to deploy to production.
-With this, pub will instead generate unminified code.
+Specifies a transformation mode. Typical values are "debug" and "release", but
+any word is allowed. Transformers may use this to change how they behave.
+
+If set to "release" pub will generate minified JavaScript using dart2js.
+Otherwise, it generates it unminified. Also, in release mode, Pub will not
+include any source .dart files in the resulting build output since they have
+been compiled to JavaScript. In any other mode, the raw Dart files will be
+included.
+
+If omitted, it defaults to "release".

--- a/app/doc/pub-serve.markdown
+++ b/app/doc/pub-serve.markdown
@@ -46,10 +46,18 @@ number, use the `--port` option:
     $ pub serve --port 9080
     Serving helloworld on http://localhost:9080
 
-### `--minify`
+### `--mode=<mode>`
 
-By default, pub serves unminified JavaScript so that it's easier to debug while
-you develop. With this, pub will instead generate minified code.
+Specifies a transformation mode. Typical values are "debug" and "release", but
+any word is allowed. Transformers may use this to change how they behave.
+
+If set to "release" pub will generate minified JavaScript using dart2js.
+Otherwise, it generates it unminified. Also, in release mode, Pub will not
+include any source .dart files in the resulting build output since they have
+been compiled to JavaScript. In any other mode, the raw Dart files will be
+included.
+
+If omitted, it defaults to "debug".
 
 ## What about Dart Editor's server?
 

--- a/app/views/doc/assets-and-transformers.html
+++ b/app/views/doc/assets-and-transformers.html
@@ -12,7 +12,9 @@ dependencies:
   <b>polymer: any</b>
 <b>transformers:
 - polymer:
-    entry_points: web/index.html</b>
+    entry_points:
+    - web/index.html
+    - web/index2.html</b>
 </pre>
 
 <p>A package&rsquo;s assets must be in one or more of the following directories:

--- a/app/views/doc/package-layout.html
+++ b/app/views/doc/package-layout.html
@@ -2,6 +2,7 @@
   <li><a href="#the-basics">The basics</a></li>
   <li><a href="#readme">README</a></li>
   <li><a href="#public-libraries">Public libraries</a></li>
+  <li><a href="#public-assets">Public assets</a></li>
   <li><a href="#implementation-files">Implementation files</a></li>
   <li><a href="#web-files">Web files</a></li>
   <li><a href="#command-line-apps">Command-line apps</a></li>
@@ -32,6 +33,8 @@ would look like:</p>
   pubspec.lock *
   README.md
   LICENSE
+  asset/
+    guacamole.css
   benchmark/
     make_lunch.dart
     packages/ **
@@ -130,7 +133,7 @@ package. This is the perfect place to introduce people to your code.</p>
 define Dart libraries that other packages can import and use. These public Dart
 library files go inside a directory called <code>lib</code>.</p>
 
-<p>Most packages will define a single library that users can import. In that case,
+<p>Most packages define a single library that users can import. In that case,
 its name should usually be the same as the name of the package, like
 <code>enchilada.dart</code> in the example here. But you can also define other libraries
 with whatever names make sense for your package.</p>
@@ -163,6 +166,41 @@ with a <code>main()</code> function&mdash;cannot go in <code>lib</code>. If you 
 inside <code>lib</code>, you will discover that any <code>package:</code> imports it contains don&rsquo;t
 resolve. Instead, your entrypoints should go in the appropriate
 <a href="glossary.html#entrypoint-directory">entrypoint directory</a>.</p>
+
+<h2 id="public-assets">Public assets</h2>
+
+<pre><code>enchilada/
+  asset/
+    guacamole.css
+</code></pre>
+
+<p>While most library packages exist to let you reuse Dart code, you can also
+reuse other kinds of content. For example, a package for something like
+<a href="http://getbootstrap.com/">Bootstrap</a> might include a number of CSS files for
+consumers of the package to use.</p>
+
+<p>These go in a top-level directory named <code>asset</code>. You can put any kind of file
+in there and organize it with subdirectories however you like. It&rsquo;s effectively
+a <code>lib</code> directory for stuff that isn&rsquo;t Dart code.</p>
+
+<p>Users can reference another package&rsquo;s assets using URLs that contain
+<code>assets/&lt;package&gt;/&lt;path&gt;</code> where <code>&lt;package&gt;</code> is the name of the package
+containing the asset and <code>&lt;path&gt;</code> is the relative path to the asset within that
+package&rsquo;s <code>asset</code> directory.</p>
+
+<p>Note that <code>assets</code> is plural in the URL. This is a bit like the split between
+<code>lib</code> and <code>packages</code>. The former is the name of the <em>directory in the package</em>,
+the latter is the <em>name you use to reference it</em>.</p>
+
+<p>For example, let&rsquo;s say your package wanted to use enchilada&rsquo;s <code>guacamole.css</code>
+styles. In an HTML file in your package, you can add:</p>
+
+<div class="highlight"><pre><code class="html"><span class="nt">&lt;link</span> <span class="na">href=</span><span class="s">&quot;assets/enchilada/guacamole.css&quot;</span> <span class="na">rel=</span><span class="s">&quot;stylesheet&quot;</span><span class="nt">&gt;</span>
+</code></pre></div>
+
+<p>When you run your application using <a href="pub-serve.html"><code>pub serve</code></a>, or build it
+to something deployable using <a href="pub-build.html"><code>pub build</code></a>, Pub will copy over
+any referenced assets that your package depends on.</p>
 
 <h2 id="implementation-files">Implementation files</h2>
 

--- a/app/views/doc/pub-build.html
+++ b/app/views/doc/pub-build.html
@@ -1,4 +1,4 @@
-<pre><code>$ pub build [--no-minify]
+<pre><code>$ pub build [--mode=&lt;mode&gt;]
 </code></pre>
 
 <p>Use <code>pub build</code> when you&rsquo;re ready to deploy your web app. When you run
@@ -37,7 +37,15 @@ development server that continuously generates and serves assets.</p>
 
 <h2 id="options">Options</h2>
 
-<h3 id="no-minify"><code>--no-minify</code></h3>
+<h3 id="modemode"><code>--mode=&lt;mode&gt;</code></h3>
 
-<p>By default, pub generates minified JavaScript ready to deploy to production.
-With this, pub will instead generate unminified code.</p>
+<p>Specifies a transformation mode. Typical values are &ldquo;debug&rdquo; and &ldquo;release&rdquo;, but
+any word is allowed. Transformers may use this to change how they behave.</p>
+
+<p>If set to &ldquo;release&rdquo; pub will generate minified JavaScript using dart2js.
+Otherwise, it generates it unminified. Also, in release mode, Pub will not
+include any source .dart files in the resulting build output since they have
+been compiled to JavaScript. In any other mode, the raw Dart files will be
+included.</p>
+
+<p>If omitted, it defaults to &ldquo;release&rdquo;.</p>

--- a/app/views/doc/pub-serve.html
+++ b/app/views/doc/pub-serve.html
@@ -47,10 +47,18 @@ number, use the <code>--port</code> option:</p>
 Serving helloworld on http://localhost:9080
 </code></pre>
 
-<h3 id="minify"><code>--minify</code></h3>
+<h3 id="modemode"><code>--mode=&lt;mode&gt;</code></h3>
 
-<p>By default, pub serves unminified JavaScript so that it&rsquo;s easier to debug while
-you develop. With this, pub will instead generate minified code.</p>
+<p>Specifies a transformation mode. Typical values are &ldquo;debug&rdquo; and &ldquo;release&rdquo;, but
+any word is allowed. Transformers may use this to change how they behave.</p>
+
+<p>If set to &ldquo;release&rdquo; pub will generate minified JavaScript using dart2js.
+Otherwise, it generates it unminified. Also, in release mode, Pub will not
+include any source .dart files in the resulting build output since they have
+been compiled to JavaScript. In any other mode, the raw Dart files will be
+included.</p>
+
+<p>If omitted, it defaults to &ldquo;debug&rdquo;.</p>
 
 <h2 id="what-about-dart-editors-server">What about Dart Editor&rsquo;s server?</h2>
 


### PR DESCRIPTION
- Get rid of --minify for build and serve.
- Document --mode.
- Document the "asset" directory.
