### PR TITLE
show all pub commands in dropdown

### DIFF
--- a/app/views/layout.mustache
+++ b/app/views/layout.mustache
@@ -59,13 +59,26 @@
                   <li><a href="https://www.dartlang.org/tools/pub/faq.html">FAQ</a></li>
                   <li><a href="https://www.dartlang.org/tools/pub/glossary.html">Glossary</a></li>
                   <li><a href="https://www.dartlang.org/tools/pub/versioning.html">Versioning Philosophy</a></li>
+                </ul>
+              </li>
+              <li class="dropdown">
+                <a class="dropdown-toggle" data-toggle="dropdown" href="#">
+                  Commands
+                  <div class="caret"></div>
+                </a>
+                <ul class="dropdown-menu">
                   <li class="nav-header">Pub Commands</li>
                   <li><a href="https://www.dartlang.org/tools/pub/cmd/pub-build.html"><code>pub build</code></a></li>
                   <li><a href="https://www.dartlang.org/tools/pub/cmd/pub-cache.html"><code>pub cache</code></a></li>
+                  <li><a href="https://www.dartlang.org/tools/pub/cmd/pub-deps.html"><code>pub deps</code></a></li>
                   <li><a href="https://www.dartlang.org/tools/pub/cmd/pub-get.html"><code>pub get</code></a></li>
+                  <li><a href="https://www.dartlang.org/tools/pub/cmd/pub-global.html"><code>pub global</code></a></li>
                   <li><a href="https://www.dartlang.org/tools/pub/cmd/pub-lish.html"><code>pub publish</code></a></li>
-                  <li><a href="https://www.dartlang.org/tools/pub/cmd/pub-upgrade.html"><code>pub upgrade</code></a></li>
+                  <li><a href="https://www.dartlang.org/tools/pub/cmd/pub-run.html"><code>pub run</code></a></li>
                   <li><a href="https://www.dartlang.org/tools/pub/cmd/pub-serve.html"><code>pub serve</code></a></li>
+                  <li><a href="https://www.dartlang.org/tools/pub/cmd/pub-upgrade.html"><code>pub upgrade</code></a></li>
+                  <li><a href="https://www.dartlang.org/tools/pub/cmd/pub-uploader.html"><code>pub uploader</code></a>
+                  </li>
                 </ul>
               </li>
               <li><a href="/packages">Packages</a></li>


### PR DESCRIPTION
Proposal to show all pub commands. Because of limited screen height a new **Commands** menu is added.

![screenshot from 2014-09-14 19 54 00](https://cloud.githubusercontent.com/assets/70635/4264974/77373b32-3c3a-11e4-9d03-8bfecec47a7f.png)
